### PR TITLE
ci(nvidia-gpu-exporter): bump checkout action and add Renovate config

### DIFF
--- a/.github/workflows/validate-plg.yml
+++ b/.github/workflows/validate-plg.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Check nvidia_gpu_exporter.plg is in sync with src/
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>mac-lucky/actions-shared-workflows"]
+}


### PR DESCRIPTION
Bumps actions/checkout to v7 in validate-plg.yml and adds renovate.json extending the shared config.